### PR TITLE
Import configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: python
+
+python: "2.7"
+
+sudo: false
+
+cache: pip
+
+install: pip install -r requirements.txt
+
+script:
+  - flake8 -v .
+  - yamllint .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flake8
+yamllint

--- a/screenA/idr0017-screenA-bulk.yml
+++ b/screenA/idr0017-screenA-bulk.yml
@@ -2,13 +2,12 @@
 continue: "true"
 transfer: "ln_s"
 exclude: "clientpath"
-checksum_algorithm: "File-Size-64"
 logprefix: "logs/"
-skip: "minmax"
+skip: "all"
 output: "yaml"
 columns:
     - name
     - path
-parallel_upload: "20"
+parallel_upload: "50"
 target: "Screen:name:idr0017-breinig-drugscreen/screenA"
 path: "idr0017-screenA-plates.tsv"

--- a/screenA/idr0017-screenA-bulk.yml
+++ b/screenA/idr0017-screenA-bulk.yml
@@ -2,7 +2,6 @@
 continue: "true"
 transfer: "ln_s"
 exclude: "clientpath"
-logprefix: "logs/"
 skip: "all"
 output: "yaml"
 columns:

--- a/screenA/idr0017-screenA-bulk.yml
+++ b/screenA/idr0017-screenA-bulk.yml
@@ -4,9 +4,11 @@ transfer: "ln_s"
 exclude: "clientpath"
 checksum_algorithm: "File-Size-64"
 logprefix: "logs/"
+skip: "minmax"
 output: "yaml"
 columns:
     - name
     - path
+parallel_upload: "20"
 target: "Screen:name:idr0017-breinig-drugscreen/screenA"
 path: "idr0017-screenA-plates.tsv"

--- a/screenA/idr0017-screenA-bulk.yml
+++ b/screenA/idr0017-screenA-bulk.yml
@@ -1,4 +1,12 @@
 ---
+continue: "true"
+transfer: "ln_s"
+exclude: "clientpath"
+checksum_algorithm: "File-Size-64"
+logprefix: "logs/"
+output: "yaml"
+columns:
+    - name
+    - path
 target: "Screen:name:idr0017-breinig-drugscreen/screenA"
-include: "../../bulk.yml"
 path: "idr0017-screenA-plates.tsv"

--- a/screenA/idr0017-screenA-bulkmap-config.yml
+++ b/screenA/idr0017-screenA-bulkmap-config.yml
@@ -3,21 +3,21 @@ name: idr0017-breinig-drugscreen/screenA
 version: 3
 
 defaults:
-    # Should the column be processed when creating bulk-annotations (yes/no)
-    include: no
-    # Columns type of the bulk-annotations column
-    type: string
+  # Should the column be processed when creating bulk-annotations (yes/no)
+  include: no
+  # Columns type of the bulk-annotations column
+  type: string
 
-    # If non-empty a string used to separate multiple fields in a column
-    # White space will be stripped
-    split:
-    # Should this column be included in the clients (yes/no)
-    includeclient: yes
-    # Should this column be visible in the clients, if no the column should be
-    # hidden in the client but will still be indexed by the searcher (yes/no)
-    visible: yes
-    # Should empty values be omitted from the client display
-    omitempty: yes
+  # If non-empty a string used to separate multiple fields in a column
+  # White space will be stripped
+  split:
+  # Should this column be included in the clients (yes/no)
+  includeclient: yes
+  # Should this column be visible in the clients, if no the column should be
+  # hidden in the client but will still be indexed by the searcher (yes/no)
+  visible: yes
+  # Should empty values be omitted from the client display
+  omitempty: yes
 
 columns:
 
@@ -41,52 +41,52 @@ columns:
   - group:
       namespace: openmicroscopy.org/mapr/organism
       columns:
-      - name: Characteristics [Organism]
-        clientname: Organism
-        include: yes
+        - name: Characteristics [Organism]
+          clientname: Organism
+          include: yes
 
   - group:
       namespace: openmicroscopy.org/mapr/cell_line
       columns:
-      - name: Characteristics [Cell Line]
-        clientname: Cell Line
-        include: yes
+        - name: Characteristics [Cell Line]
+          clientname: Cell Line
+          include: yes
 
   - group:
       namespace: openmicroscopy.org/mapr/cell_line/supplementary
       columns:
-      - name: Mutation Detailed
-        include: yes
+        - name: Mutation Detailed
+          include: yes
 
   - group:
       namespace: openmicroscopy.org/mapr/compound
       columns:
-      - name: Compound Name
-        include: yes
-      - name: Compound Name
-        clientname: Compound Name URL
-        clientvalue: https://www.ncbi.nlm.nih.gov/pccompound?term={{ value|urlencode }}
-        include: yes
+        - name: Compound Name
+          include: yes
+        - name: Compound Name
+          clientname: Compound Name URL
+          clientvalue: https://www.ncbi.nlm.nih.gov/pccompound?term={{ value|urlencode }}
+          include: yes
 
   - group:
       namespace: openmicroscopy.org/mapr/compound/supplementary
       columns:
-      - name: Compound Treatment
-        include: yes
-      - name: Compound Secondary Name
-        include: yes
-      - name: Compound Class
-        include: yes
-      - name: Compound Enzyme
-        include: yes
-      - name: Compound Action
-        include: yes
-      - name: Compound Selectivity
-        include: yes
-      - name: Compound Description
-        include: yes
-      - name: Compound Selectivity Updated
-        include: yes
+        - name: Compound Treatment
+          include: yes
+        - name: Compound Secondary Name
+          include: yes
+        - name: Compound Class
+          include: yes
+        - name: Compound Enzyme
+          include: yes
+        - name: Compound Action
+          include: yes
+        - name: Compound Selectivity
+          include: yes
+        - name: Compound Description
+          include: yes
+        - name: Compound Selectivity Updated
+          include: yes
 
 
 # Advanced options (experimental)
@@ -98,12 +98,12 @@ advanced:
     # TODO: Primary key config should be in a global config
     ignore_missing_primary_key: yes
     primary_group_keys:
-    - namespace: openmicroscopy.org/mapr/organism
-      keys:
-      - Organism
-    - namespace: openmicroscopy.org/mapr/cell_line
-      keys:
-      - Cell Line
-    - namespace: openmicroscopy.org/mapr/compound
-      keys:
-      - Compound Name
+      - namespace: openmicroscopy.org/mapr/organism
+        keys:
+          - Organism
+      - namespace: openmicroscopy.org/mapr/cell_line
+        keys:
+          - Cell Line
+      - namespace: openmicroscopy.org/mapr/compound
+        keys:
+          - Compound Name

--- a/screenA/idr0017-screenA-bulkmap-config.yml
+++ b/screenA/idr0017-screenA-bulkmap-config.yml
@@ -65,7 +65,8 @@ columns:
           include: yes
         - name: Compound Name
           clientname: Compound Name URL
-          clientvalue: https://www.ncbi.nlm.nih.gov/pccompound?term={{ value|urlencode }}
+          clientvalue: >
+            https://www.ncbi.nlm.nih.gov/pccompound?term={{ value|urlencode }}
           include: yes
 
   - group:
@@ -91,19 +92,19 @@ columns:
 
 # Advanced options (experimental)
 advanced:
-    # If a map-annotation is attached to a well also attach it to all images
-    # in the well
-    well_to_images: yes
+  # If a map-annotation is attached to a well also attach it to all images
+  # in the well
+  well_to_images: yes
 
-    # TODO: Primary key config should be in a global config
-    ignore_missing_primary_key: yes
-    primary_group_keys:
-      - namespace: openmicroscopy.org/mapr/organism
-        keys:
-          - Organism
-      - namespace: openmicroscopy.org/mapr/cell_line
-        keys:
-          - Cell Line
-      - namespace: openmicroscopy.org/mapr/compound
-        keys:
-          - Compound Name
+  # TODO: Primary key config should be in a global config
+  ignore_missing_primary_key: yes
+  primary_group_keys:
+    - namespace: openmicroscopy.org/mapr/organism
+      keys:
+        - Organism
+    - namespace: openmicroscopy.org/mapr/cell_line
+      keys:
+        - Cell Line
+    - namespace: openmicroscopy.org/mapr/compound
+      keys:
+        - Compound Name


### PR DESCRIPTION
Post decoupling of this repository from https://github.com/IDR/idr-metadata, this adds a couple of options to import the breinig screen into testing servers.

The scope of this work is to import and annotate an IDR study with a large number of Homo Sapiens canonical map annotations (~100K) in order to investigate issues with the graph deletion. /cc @mtbc 